### PR TITLE
changed images tagging scheme for a time based version

### DIFF
--- a/supertuxkart/ci/game-load-simu/linux-arm/lib/pipeline-stack.ts
+++ b/supertuxkart/ci/game-load-simu/linux-arm/lib/pipeline-stack.ts
@@ -28,12 +28,6 @@ export class gameLoadSimuPipeline extends Stack {
   });
   
   
-  const baseImageVersion = new CfnParameter(this, "baseImageVersion", {
-  type: "String",
-  description: "The supertuxkart docker image version",
-  default: "latest"
-  });
-  
   const ecrRepoName = new CfnParameter(this, "ecrRepoName", {
   type: "String",
   description: "The name of the ecr registry",
@@ -74,9 +68,9 @@ export class gameLoadSimuPipeline extends Stack {
         version: "0.2",
         phases: {
           build: {
-            commands: [`docker build -t ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:${baseImageVersion.valueAsString} .`,
+            commands: [`TAG=$(date +'%Y%m%d%H%M%S')`,`docker build -t ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:$TAG .`,
             `aws ecr get-login-password --region ${this.region} | docker login --username AWS --password-stdin ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}`,
-            `docker push ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:${baseImageVersion.valueAsString}`],
+            `docker push ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:$TAG`],
           }
            
         },

--- a/supertuxkart/ci/game-server/linux-arm/lib/pipeline-stack.ts
+++ b/supertuxkart/ci/game-server/linux-arm/lib/pipeline-stack.ts
@@ -28,12 +28,6 @@ export class StkPipelineStack extends Stack {
   });
   
   
-  const baseImageVersion = new CfnParameter(this, "baseImageVersion", {
-  type: "String",
-  description: "The supertuxkart docker image version",
-  default: "latest"
-  });
-  
   const ecrRepoName = new CfnParameter(this, "ecrRepoName", {
   type: "String",
   description: "The name of the ecr registry",
@@ -74,9 +68,9 @@ export class StkPipelineStack extends Stack {
         version: "0.2",
         phases: {
           build: {
-            commands: [`docker build -t ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:${baseImageVersion.valueAsString} .`,
+            commands: [`TAG=$(date +'%Y%m%d%H%M%S')`,`docker build -t ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:$TAG .`,
             `aws ecr get-login-password --region ${this.region} | docker login --username AWS --password-stdin ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}`,
-            `docker push ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:${baseImageVersion.valueAsString}`],
+            `docker push ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:$TAG`],
           }
            
         },


### PR DESCRIPTION
*Issue #, if available:*

Previously the docker images were always tagged as "latest". We need a different version for each image. 

*Description of changes:*

Removed the baseImageVersion parameter and added logic to the code build commands to generate a timestamp and append it to the docker images. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
