### PR TITLE
added capabilities to deploy to an EKS cluster in the same account

### DIFF
--- a/supertuxkart/ci/game-load-simu/linux-amd64/lib/pipeline-stack.ts
+++ b/supertuxkart/ci/game-load-simu/linux-amd64/lib/pipeline-stack.ts
@@ -1,13 +1,15 @@
-import { Stack, StackProps, CfnParameter  } from 'aws-cdk-lib';
-import { Construct } from 'constructs'
-import * as codecommit from 'aws-cdk-lib/aws-codecommit';
-import * as sns from 'aws-cdk-lib/aws-sns';
-import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
-import * as ecr from 'aws-cdk-lib/aws-ecr';
-import * as codebuild from 'aws-cdk-lib/aws-codebuild';
-import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
-import * as codepipeline_actions from 'aws-cdk-lib/aws-codepipeline-actions';
-import * as notifications from 'aws-cdk-lib/aws-codestarnotifications';
+import { Stack, StackProps, CfnParameter, RemovalPolicy, CfnOutput } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import * as codecommit from "aws-cdk-lib/aws-codecommit";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import * as codepipeline from "aws-cdk-lib/aws-codepipeline";
+import * as codepipeline_actions from "aws-cdk-lib/aws-codepipeline-actions";
+import * as notifications from "aws-cdk-lib/aws-codestarnotifications";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as eks from "aws-cdk-lib/aws-eks";
 
 export class gameLoadSimuPipeline extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -15,11 +17,11 @@ export class gameLoadSimuPipeline extends Stack {
 
   //parameters that can be passed from the command line
   
-//  const notificationEmail = new CfnParameter(this, "notificationEmail", {
-//  type: "String",
-//  description: "The recipient email for pipeline notifications",
-//  default: "xyz@amazon.com"
-//  });
+  const notificationEmail = new CfnParameter(this, "notificationEmail", {
+  type: "String",
+  description: "The recipient email for pipeline notifications",
+  default: "xyz@amazon.com"
+  });
   
   const gitRepoName = new CfnParameter(this, "gitRepoName", {
   type: "String",
@@ -50,16 +52,35 @@ export class gameLoadSimuPipeline extends Stack {
   });
     
   //sns topic for pipeline notifications
- // const pipelineNotifications = new sns.Topic(this, 'BuildNotifications');
-  //pipelineNotifications.addSubscription(new subscriptions.EmailSubscription(`${notificationEmail.valueAsString}`));
+  const pipelineNotifications = new sns.Topic(this, 'BuildNotifications');
+  pipelineNotifications.addSubscription(new subscriptions.EmailSubscription(`${notificationEmail.valueAsString}`));
     
     
   //docker repository to store container images
   const registry = new ecr.Repository(this,`game-servers`, {
       repositoryName: ecrRepoName.valueAsString,
       imageScanOnPush: true,
+      removalPolicy: RemovalPolicy.DESTROY
+    });
+    
+     //name of target EKS cluster
+    const clusterName = new CfnParameter(this, "clusterName", {
+      type: "String",
+      description: "The name of the EKS cluster",
+      default: "stk-gameservers",
     });
 
+
+   //create a roleARN for codebuild 
+    const deployRole = new iam.Role(this, 'codeBuildDeployRole', { roleName: "codeBuildDeployRole",
+      assumedBy: new iam.ServicePrincipal('codebuild.amazonaws.com'),
+    });
+    
+    
+     deployRole.addToPolicy(new iam.PolicyStatement({
+      resources: ['*'],
+      actions: ['ssm:*'],
+    }));
     
   //codebuild project to build docker containers
   // we are reading the build spec from the code, but you could also read it from a file
@@ -67,16 +88,20 @@ export class gameLoadSimuPipeline extends Stack {
   const buildproject = new codebuild.Project(this, `gameLoadSimuDockerBuild`, {
        environment: {
             privileged: true,
-            buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2
+            buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_ARM_2
          },
       //cache: codebuild.Cache.local(codebuild.LocalCacheMode.DOCKER_LAYER, codebuild.LocalCacheMode.CUSTOM),
       buildSpec: codebuild.BuildSpec.fromObject({
         version: "0.2",
         phases: {
           build: {
-            commands: [`docker build -t ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:${baseImageVersion.valueAsString} .`,
-            `aws ecr get-login-password --region ${this.region} | docker login --username AWS --password-stdin ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}`,
-            `docker push ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:${baseImageVersion.valueAsString}`],
+            commands: [
+              `TAG=$(date +'%Y%m%d%H%M%S')`,
+              `docker build -t ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:$TAG .`,
+              `aws ecr get-login-password --region ${this.region} | docker login --username AWS --password-stdin ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}`,
+              `docker push ${this.account}.dkr.ecr.${this.region}.amazonaws.com/${registry.repositoryName}:$TAG`,
+              `aws ssm put-parameter --type String --name ${ gitRepoName.valueAsString }-image-latest-tag --value $TAG --overwrite`
+              ],
           }
            
         },
@@ -84,6 +109,44 @@ export class gameLoadSimuPipeline extends Stack {
              files: ['imageDetail.json']
            },
         
+      }),
+    });
+    
+    //giving permissions to codebuild for eks
+    deployRole.addToPolicy(new iam.PolicyStatement({
+      resources: ['*'],
+      actions: ['eks:*'],
+    }));
+    
+     new CfnOutput(this, 'iamidentitymapping command', { value: `eksctl create iamidentitymapping --cluster ${  clusterName.valueAsString } --region ${ this.region  } --arn ${ deployRole.roleArn } --group system:masters` });
+
+    //deploy docker image using codebuild
+    
+    const deployproject = new codebuild.Project(this, `dockerDeploy`, {
+      environment: {
+        privileged: true,
+        buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2,
+      },
+      role: deployRole,
+      
+      buildSpec: codebuild.BuildSpec.fromObject({
+        version: "0.2",
+        phases: {
+          build: {
+            commands: [
+              `export AWS_REGION=${ this.region  }`,
+              `export AWS_ACCOUNT_ID=${ this.account }`,
+              `curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp`,
+              `mv /tmp/eksctl /usr/local/bin`,
+              `aws eks update-kubeconfig --region ${ this.region } --name ${ clusterName.valueAsString }`,
+              "IMAGE_TAG=$(aws ssm get-parameter --name sample-cluster-app-image-latest-tag | jq '.Parameter.Value')",
+              "envsubst < sample-cluster-app-deployment.yml | kubectl apply -f -"
+            ],
+          },
+        },
+        artifacts: {
+          files: ["imageDetail.json"],
+        },
       }),
     });
     
@@ -116,20 +179,39 @@ export class gameLoadSimuPipeline extends Stack {
              
             }),
           ]
-        }
+        },
+        {
+          stageName: "EKSDeployment",
+          actions: [
+            new codepipeline_actions.CodeBuildAction({
+              actionName: "Deploy_Code",
+              input: sourceOuput,
+              project: deployproject,
+            }),
+          ],
+        },
       ]
     });
     
 
     
-    //const buildNotificationRule = new notifications.NotificationRule(this, 'buildNotificationRule', {
-    //source: buildproject,
-    //events: [
-    //  'codebuild-project-build-state-succeeded',
-    //  'codebuild-project-build-state-failed',
-    //],
-    //targets: [pipelineNotifications],
-  //});
+    const buildNotificationRule = new notifications.NotificationRule(this, 'buildNotificationRule', {
+    source: buildproject,
+    events: [
+      'codebuild-project-build-state-succeeded',
+      'codebuild-project-build-state-failed',
+    ],
+    targets: [pipelineNotifications],
+  });
+  
+   const deployNotificationRule = new notifications.NotificationRule(this, 'deployNotificationRule', {
+    source: deployproject,
+    events: [
+      'codebuild-project-build-state-succeeded',
+      'codebuild-project-build-state-failed',
+    ],
+    targets: [pipelineNotifications],
+  });
 
   }
 }

--- a/supertuxkart/ci/game-server/linux-aarch64/README.md
+++ b/supertuxkart/ci/game-server/linux-aarch64/README.md
@@ -12,6 +12,9 @@ Configure the notification email you wish to get notifications about build statu
 
 Execute ./init.sh
 
+Execute the command returned as output to allow depoyments on EKS: `PipelineStack.iamidentitymappingcommand = eksctl create iamidentitymapping --cluster <cluster> --region <region> --arn arn:aws:iam::<account>:role/codeBuildDeployRole --group system:masters`
+
+
 # What does it do?
 
 CDK will provision a new ECR image registry and CodeCommit repository, copy the configuration stored in (./dockerfiles)[./dockerfiles] to the CodeCommit repository and kick the build process upon git merges/pushes to the CodeCommit repo. 

--- a/supertuxkart/ci/game-server/linux-aarch64/cdk.out/StkPipelineStack1.assets.json
+++ b/supertuxkart/ci/game-server/linux-aarch64/cdk.out/StkPipelineStack1.assets.json
@@ -1,31 +1,31 @@
 {
   "version": "17.0.0",
   "files": {
-    "3a595d4ac74e2fc3f6b6d4d1c8b6188c276ba834ef57ca8bfb787173779bb9d5": {
+    "a549c87403d0052d036db7a619ca1da1b8517460c7db9b61a598cd325246d8ee": {
       "source": {
-        "path": "asset.3a595d4ac74e2fc3f6b6d4d1c8b6188c276ba834ef57ca8bfb787173779bb9d5",
+        "path": "asset.a549c87403d0052d036db7a619ca1da1b8517460c7db9b61a598cd325246d8ee",
         "packaging": "zip"
       },
       "destinations": {
-        "212076617619-us-west-2": {
-          "bucketName": "cdk-hnb659fds-assets-212076617619-us-west-2",
-          "objectKey": "3a595d4ac74e2fc3f6b6d4d1c8b6188c276ba834ef57ca8bfb787173779bb9d5.zip",
-          "region": "us-west-2",
-          "assumeRoleArn": "arn:${AWS::Partition}:iam::212076617619:role/cdk-hnb659fds-file-publishing-role-212076617619-us-west-2"
+        "742301976366-us-east-2": {
+          "bucketName": "cdk-hnb659fds-assets-742301976366-us-east-2",
+          "objectKey": "a549c87403d0052d036db7a619ca1da1b8517460c7db9b61a598cd325246d8ee.zip",
+          "region": "us-east-2",
+          "assumeRoleArn": "arn:${AWS::Partition}:iam::742301976366:role/cdk-hnb659fds-file-publishing-role-742301976366-us-east-2"
         }
       }
     },
-    "f9a8b5ccb4fb65c0b37f65b1706d68c86d54749866dbdd9a4ab151f51a94b2e7": {
+    "46403ad1ea528110b696f66d9615e60479d2d2857f4c7aea846b20731542cbce": {
       "source": {
         "path": "StkPipelineStack1.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "212076617619-us-west-2": {
-          "bucketName": "cdk-hnb659fds-assets-212076617619-us-west-2",
-          "objectKey": "f9a8b5ccb4fb65c0b37f65b1706d68c86d54749866dbdd9a4ab151f51a94b2e7.json",
-          "region": "us-west-2",
-          "assumeRoleArn": "arn:${AWS::Partition}:iam::212076617619:role/cdk-hnb659fds-file-publishing-role-212076617619-us-west-2"
+        "742301976366-us-east-2": {
+          "bucketName": "cdk-hnb659fds-assets-742301976366-us-east-2",
+          "objectKey": "46403ad1ea528110b696f66d9615e60479d2d2857f4c7aea846b20731542cbce.json",
+          "region": "us-east-2",
+          "assumeRoleArn": "arn:${AWS::Partition}:iam::742301976366:role/cdk-hnb659fds-file-publishing-role-742301976366-us-east-2"
         }
       }
     }

--- a/supertuxkart/ci/game-server/linux-aarch64/cdk.out/StkPipelineStack1.template.json
+++ b/supertuxkart/ci/game-server/linux-aarch64/cdk.out/StkPipelineStack1.template.json
@@ -36,8 +36,8 @@
     "Code": {
      "BranchName": "main",
      "S3": {
-      "Bucket": "cdk-hnb659fds-assets-212076617619-us-west-2",
-      "Key": "3a595d4ac74e2fc3f6b6d4d1c8b6188c276ba834ef57ca8bfb787173779bb9d5.zip"
+      "Bucket": "cdk-hnb659fds-assets-742301976366-us-east-2",
+      "Key": "a549c87403d0052d036db7a619ca1da1b8517460c7db9b61a598cd325246d8ee.zip"
      }
     },
     "RepositoryDescription": "New repository for demo project."
@@ -85,7 +85,7 @@
          {
           "Ref": "AWS::Partition"
          },
-         ":codepipeline:us-west-2:212076617619:",
+         ":codepipeline:us-east-2:742301976366:",
          {
           "Ref": "containerPipelineE427408B"
          }
@@ -169,7 +169,7 @@
            {
             "Ref": "AWS::Partition"
            },
-           ":logs:us-west-2:212076617619:log-group:/aws/codebuild/",
+           ":logs:us-east-2:742301976366:log-group:/aws/codebuild/",
            {
             "Ref": "STKgameServerDockerBuild16674040"
            }
@@ -184,7 +184,7 @@
            {
             "Ref": "AWS::Partition"
            },
-           ":logs:us-west-2:212076617619:log-group:/aws/codebuild/",
+           ":logs:us-east-2:742301976366:log-group:/aws/codebuild/",
            {
             "Ref": "STKgameServerDockerBuild16674040"
            },
@@ -211,7 +211,7 @@
           {
            "Ref": "AWS::Partition"
           },
-          ":codebuild:us-west-2:212076617619:report-group/",
+          ":codebuild:us-east-2:742301976366:report-group/",
           {
            "Ref": "STKgameServerDockerBuild16674040"
           },
@@ -350,7 +350,7 @@
       "Fn::Join": [
        "",
        [
-        "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"docker build -t 212076617619.dkr.ecr.us-west-2.amazonaws.com/",
+        "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"docker build -t 742301976366.dkr.ecr.us-east-2.amazonaws.com/",
         {
          "Ref": "gameservers96C3BF90"
         },
@@ -358,11 +358,11 @@
         {
          "Ref": "baseImageVersion"
         },
-        " .\",\n        \"aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 212076617619.dkr.ecr.us-west-2.amazonaws.com/",
+        " .\",\n        \"aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 742301976366.dkr.ecr.us-east-2.amazonaws.com/",
         {
          "Ref": "gameservers96C3BF90"
         },
-        "\",\n        \"docker push 212076617619.dkr.ecr.us-west-2.amazonaws.com/",
+        "\",\n        \"docker push 742301976366.dkr.ecr.us-east-2.amazonaws.com/",
         {
          "Ref": "gameservers96C3BF90"
         },
@@ -407,7 +407,7 @@
            {
             "Ref": "AWS::Partition"
            },
-           ":iam::212076617619:root"
+           ":iam::742301976366:root"
           ]
          ]
         }
@@ -753,7 +753,7 @@
            {
             "Ref": "AWS::Partition"
            },
-           ":iam::212076617619:root"
+           ":iam::742301976366:root"
           ]
          ]
         }
@@ -891,7 +891,7 @@
           {
            "Ref": "AWS::Partition"
           },
-          ":codepipeline:us-west-2:212076617619:",
+          ":codepipeline:us-east-2:742301976366:",
           {
            "Ref": "containerPipelineE427408B"
           }
@@ -930,7 +930,7 @@
            {
             "Ref": "AWS::Partition"
            },
-           ":iam::212076617619:root"
+           ":iam::742301976366:root"
           ]
          ]
         }
@@ -980,7 +980,7 @@
   "CDKMetadata": {
    "Type": "AWS::CDK::Metadata",
    "Properties": {
-    "Analytics": "v2:deflate64:H4sIAAAAAAAA/31Ru27DMAz8lu6y2rpDuiYduxhu90CR2YC2HoYopwgE/Xso2YW3TndHkccD1cq2lS9P6pcaPUyNwYtMX1HpSXz8uE4FZSFCEPx+TtoPoL21GGXqYfaE0Yd7adxVFvR2VkQQSR4LsJbptOgJ4kkRiJWWoY2t0HmD+r6XV50F3MCxVeoXA3UTI+9wXPr2M+pSq4RbdfgvV0l/WdAMMnXBj6BriI1mgcrytN+2FNwj/YUpFjPOYNABu2ysdmw8i8lytE+ocwWOBhUVUUnOol6FT3xFd10zkl+C5lHH9nKk59vrQb7zp4yE2ITFRbQg+xUfBzpjhLABAAA="
+    "Analytics": "v2:deflate64:H4sIAAAAAAAA/31Ru27DMAz8lu6y2rhF96RjF8PpHigyG9DWwxDlFIGgfy8lu/DW6e4o8nigWtm28uVJ/VCjh6kxeJXpHJWexMe361RQFiIEwe+XpP0A2luLUaYeZk8YfXiUxl1lQa8XRQSR5LEAa5lOi54gnhSBWGkZ2tgKnTeoH3t51VnAHRxbpX4xUDcx8g7HpS8/oy61SrhVh/9ylfTXBc0gUxf8CLqG2GgWqCxP+21LwT3SX5hiMeMMBh2wy8Zqx8azmCxH+4Q6V+BoUFERleQs6lX4xDd0tzUj+SVoHnVsL0d6vh/e5eGNf2UkxCYsLqIF2a/4C3EWwoqxAQAA"
    },
    "Metadata": {
     "aws:cdk:path": "StkPipelineStack1/CDKMetadata/Default"

--- a/supertuxkart/ci/game-server/linux-aarch64/cdk.out/manifest.json
+++ b/supertuxkart/ci/game-server/linux-aarch64/cdk.out/manifest.json
@@ -17,20 +17,20 @@
     },
     "StkPipelineStack1": {
       "type": "aws:cloudformation:stack",
-      "environment": "aws://212076617619/us-west-2",
+      "environment": "aws://742301976366/us-east-2",
       "properties": {
         "templateFile": "StkPipelineStack1.template.json",
         "validateOnSynth": false,
-        "assumeRoleArn": "arn:${AWS::Partition}:iam::212076617619:role/cdk-hnb659fds-deploy-role-212076617619-us-west-2",
-        "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::212076617619:role/cdk-hnb659fds-cfn-exec-role-212076617619-us-west-2",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-212076617619-us-west-2/f9a8b5ccb4fb65c0b37f65b1706d68c86d54749866dbdd9a4ab151f51a94b2e7.json",
+        "assumeRoleArn": "arn:${AWS::Partition}:iam::742301976366:role/cdk-hnb659fds-deploy-role-742301976366-us-east-2",
+        "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::742301976366:role/cdk-hnb659fds-cfn-exec-role-742301976366-us-east-2",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-742301976366-us-east-2/46403ad1ea528110b696f66d9615e60479d2d2857f4c7aea846b20731542cbce.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
           "StkPipelineStack1.assets"
         ],
         "lookupRole": {
-          "arn": "arn:${AWS::Partition}:iam::212076617619:role/cdk-hnb659fds-lookup-role-212076617619-us-west-2",
+          "arn": "arn:${AWS::Partition}:iam::742301976366:role/cdk-hnb659fds-lookup-role-742301976366-us-east-2",
           "requiresBootstrapStackVersion": 8,
           "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version"
         }

--- a/supertuxkart/ci/game-server/linux-aarch64/cdk.out/tree.json
+++ b/supertuxkart/ci/game-server/linux-aarch64/cdk.out/tree.json
@@ -90,8 +90,8 @@
                     "code": {
                       "branchName": "main",
                       "s3": {
-                        "bucket": "cdk-hnb659fds-assets-212076617619-us-west-2",
-                        "key": "3a595d4ac74e2fc3f6b6d4d1c8b6188c276ba834ef57ca8bfb787173779bb9d5.zip"
+                        "bucket": "cdk-hnb659fds-assets-742301976366-us-east-2",
+                        "key": "a549c87403d0052d036db7a619ca1da1b8517460c7db9b61a598cd325246d8ee.zip"
                       }
                     },
                     "repositoryDescription": "New repository for demo project."
@@ -149,7 +149,7 @@
                                   {
                                     "Ref": "AWS::Partition"
                                   },
-                                  ":codepipeline:us-west-2:212076617619:",
+                                  ":codepipeline:us-east-2:742301976366:",
                                   {
                                     "Ref": "containerPipelineE427408B"
                                   }
@@ -295,7 +295,7 @@
                                           {
                                             "Ref": "AWS::Partition"
                                           },
-                                          ":logs:us-west-2:212076617619:log-group:/aws/codebuild/",
+                                          ":logs:us-east-2:742301976366:log-group:/aws/codebuild/",
                                           {
                                             "Ref": "STKgameServerDockerBuild16674040"
                                           }
@@ -310,7 +310,7 @@
                                           {
                                             "Ref": "AWS::Partition"
                                           },
-                                          ":logs:us-west-2:212076617619:log-group:/aws/codebuild/",
+                                          ":logs:us-east-2:742301976366:log-group:/aws/codebuild/",
                                           {
                                             "Ref": "STKgameServerDockerBuild16674040"
                                           },
@@ -337,7 +337,7 @@
                                         {
                                           "Ref": "AWS::Partition"
                                         },
-                                        ":codebuild:us-west-2:212076617619:report-group/",
+                                        ":codebuild:us-east-2:742301976366:report-group/",
                                         {
                                           "Ref": "STKgameServerDockerBuild16674040"
                                         },
@@ -494,7 +494,7 @@
                         "Fn::Join": [
                           "",
                           [
-                            "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"docker build -t 212076617619.dkr.ecr.us-west-2.amazonaws.com/",
+                            "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"docker build -t 742301976366.dkr.ecr.us-east-2.amazonaws.com/",
                             {
                               "Ref": "gameservers96C3BF90"
                             },
@@ -502,11 +502,11 @@
                             {
                               "Ref": "baseImageVersion"
                             },
-                            " .\",\n        \"aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 212076617619.dkr.ecr.us-west-2.amazonaws.com/",
+                            " .\",\n        \"aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 742301976366.dkr.ecr.us-east-2.amazonaws.com/",
                             {
                               "Ref": "gameservers96C3BF90"
                             },
-                            "\",\n        \"docker push 212076617619.dkr.ecr.us-west-2.amazonaws.com/",
+                            "\",\n        \"docker push 742301976366.dkr.ecr.us-east-2.amazonaws.com/",
                             {
                               "Ref": "gameservers96C3BF90"
                             },
@@ -569,7 +569,7 @@
                                       {
                                         "Ref": "AWS::Partition"
                                       },
-                                      ":iam::212076617619:root"
+                                      ":iam::742301976366:root"
                                     ]
                                   ]
                                 }
@@ -1008,7 +1008,7 @@
                                               {
                                                 "Ref": "AWS::Partition"
                                               },
-                                              ":iam::212076617619:root"
+                                              ":iam::742301976366:root"
                                             ]
                                           ]
                                         }
@@ -1197,7 +1197,7 @@
                                         {
                                           "Ref": "AWS::Partition"
                                         },
-                                        ":codepipeline:us-west-2:212076617619:",
+                                        ":codepipeline:us-east-2:742301976366:",
                                         {
                                           "Ref": "containerPipelineE427408B"
                                         }
@@ -1265,7 +1265,7 @@
                                               {
                                                 "Ref": "AWS::Partition"
                                               },
-                                              ":iam::212076617619:root"
+                                              ":iam::742301976366:root"
                                             ]
                                           ]
                                         }

--- a/supertuxkart/ci/game-server/linux-aarch64/init.sh
+++ b/supertuxkart/ci/game-server/linux-aarch64/init.sh
@@ -6,4 +6,4 @@ npm install aws-cdk-lib
 . ~/.bash_profile
 cdk bootstrap aws://$account/$region
 npm install
-cdk deploy --parameters notificationEmail=birayaha@amazon.com --parameters gitRepoName=stk-server-docker-build1
+cdk deploy --parameters notificationEmail=pouemes@amazon.com --parameters gitRepoName=stk-server-docker-build1

--- a/supertuxkart/ci/game-server/linux-amd64/README.md
+++ b/supertuxkart/ci/game-server/linux-amd64/README.md
@@ -12,6 +12,8 @@ Configure the notification email you wish to get notifications about build statu
 
 Execute ./init.sh
 
+Execute the command returned as output to allow depoyments on EKS: `PipelineStack.iamidentitymappingcommand = eksctl create iamidentitymapping --cluster <cluster> --region <region> --arn arn:aws:iam::<account>:role/codeBuildDeployRole --group system:masters`
+
 # What does it do?
 
 CDK will provision a new ECR image registry and CodeCommit repository, copy the configuration stored in (./dockerfiles)[./dockerfiles] to the CodeCommit repository and kick the build process upon git merges/pushes to the CodeCommit repo. 


### PR DESCRIPTION

*Description of changes:*
We added the capability to deploy the image built to an EKS cluster. We use EKSCTL to retrieve the kubeconfig for the cluster and we give permissions to codebuild to deploy to EKS. CodeBuild calls kubectl and leverages Parameters store to get the last version of the image to deploy. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
